### PR TITLE
Event files can include other event files

### DIFF
--- a/events/visual_servoing_events
+++ b/events/visual_servoing_events
@@ -1,5 +1,3 @@
 VisualServoingEventManager:
-  Land
-  Takeoff
-  Abort
+  basic_events/BasicEventManager
   FollowTrajectory

--- a/scripts/generate_event_file.py
+++ b/scripts/generate_event_file.py
@@ -5,6 +5,7 @@
 
 import sys
 import os
+import re
 
 # %%
 
@@ -116,6 +117,18 @@ def check_event_manager(event_name):
     return False
 
 
+def check_event_name(event_name):
+    if '/' in event_name:
+      variable_pattern = re.compile('^[a-zA-Z_]\w*/[a-zA-Z_]\w*')
+      match_obj = variable_pattern.match(event_name)
+    else:
+      variable_pattern = re.compile('^[a-zA-Z_]\w*')
+      match_obj = variable_pattern.match(event_name)
+
+    if match_obj is None or match_obj.group() != event_name:
+      raise Exception("Variable name does not match c++ conventions: {0}".format(event_name))
+
+
 def create_sub_event_manager(event_name, accumulate_event_manager_classes,
                              accumulate_event_manager_names, out_file):
     event_manager_tuple = event_name.split('/')
@@ -160,6 +173,7 @@ if __name__ == "__main__":
     print >>out_file, ""
     for event_name in event_names_list[1:]:
         event_name = event_name.strip()
+        check_event_name(event_name)
         create_sub_event_manager(event_name, accumulate_event_manager_classes,
                                  accumulate_event_manager_names, out_file)
     print >>out_file, ""

--- a/scripts/generate_event_file.py
+++ b/scripts/generate_event_file.py
@@ -30,7 +30,37 @@ def create_event(event_name, accumulate_event_map, out_file):
         '{{"{0}", generate_{0}<LogicStateMachine>}}'.format(event_name))
 
 
-def create_event_manager(event_manager_name, accumulate_event_map, out_file):
+def create_sub_event_managers(
+        accumulate_event_manager_classes,
+        accumulate_event_manager_names,
+        out_file):
+    for i, event_manager_class in enumerate(accumulate_event_manager_classes):
+        event_manager_name = accumulate_event_manager_names[i]
+        print >>out_file, ("    {0} {1};").format(event_manager_class,
+                                                  event_manager_name,)
+
+
+def create_sub_event_manager_triggers(
+        accumulate_event_manager_names, out_file):
+    for event_manager_name in accumulate_event_manager_names:
+        print >>out_file, (
+            "      if(!event_found) {{\n"
+            "        event_found = {0}.triggerEvent(event_name, logic_state_machine);\n"
+            "      }}").format(event_manager_name,)
+
+
+def create_sub_event_sets(accumulate_event_manager_names, out_file):
+    for event_manager_name in accumulate_event_manager_names:
+        print >>out_file, (
+            "      {{\n"
+            "        std::set<std::string> sub_event_set = {0}.getEventSet();\n"
+            "        event_set.insert(sub_event_set.begin(), sub_event_set.end());\n"
+            "      }}").format(event_manager_name,)
+
+
+def create_event_manager(event_manager_name, accumulate_event_map,
+                         accumulate_event_manager_classes,
+                         accumulate_event_manager_names, out_file):
     """
     Create event manager class. This class provides functions to trigger
     an event by name, and print all the events managed by the class. The
@@ -42,27 +72,62 @@ def create_event_manager(event_manager_name, accumulate_event_map, out_file):
         "  class {0} {{\n"
         "    typedef std::function<void(LogicStateMachine&)> EventFunction;\n"
         "    std::unordered_map<std::string, EventFunction> event_map = {{\n\t{1},\n"
-        "    }};\n"
+        "    }};").format(
+        event_manager_name, ',\n\t'.join(accumulate_event_map),)
+
+    create_sub_event_managers(accumulate_event_manager_classes,
+                              accumulate_event_manager_names, out_file)
+
+    print >>out_file, (
         "    public:\n"
-        "    void triggerEvent(std::string event_name,"
-        " LogicStateMachine& logic_state_machine) {{\n"
+        "    bool triggerEvent(std::string event_name,"
+        " LogicStateMachine& logic_state_machine) {\n"
+        "      bool event_found = false;\n"
         "      auto node = event_map.find(event_name);\n"
-        "      if(node != event_map.end()) {{\n"
+        "      if(node != event_map.end()) {\n"
         "        event_map[event_name](logic_state_machine);\n"
-        "      }}\n"
-        "      else {{\n"
-        "        throw std::runtime_error(event_name + \"not found\");\n"
-        "      }}\n"
-        "      return;\n"
-        "    }}\n"
-        "    std::set<std::string> getEventSet() {{\n"
+        "        event_found = true;\n"
+        "      }")
+
+    create_sub_event_manager_triggers(accumulate_event_manager_names, out_file)
+
+    print >>out_file, (
+        "      return event_found;\n"
+        "    }\n"
+        "    std::set<std::string> getEventSet() {\n"
         "      std::set<std::string> event_set;\n"
-        "      for(auto &s : event_map) {{\n"
+        "      for(auto &s : event_map) {\n"
         "         event_set.insert(s.first);\n"
-        "      }}\n"
+        "      }\n\n"
+        "      //Generate Event set for sub machines if present")
+
+    create_sub_event_sets(accumulate_event_manager_names, out_file)
+
+    print >>out_file, (
         "      return event_set;\n"
-        "    }}\n"
-        "  }};").format(event_manager_name, ',\n\t'.join(accumulate_event_map),)
+        "    }\n"
+        "  };")
+
+
+def check_event_manager(event_name):
+    event_manager_tuple = event_name.split('/')
+    if len(event_manager_tuple) == 2:
+        return True
+    return False
+
+
+def create_sub_event_manager(event_name, accumulate_event_manager_classes,
+                             accumulate_event_manager_names, out_file):
+    event_manager_tuple = event_name.split('/')
+    if len(event_manager_tuple) == 2:
+        print >>out_file, (
+            "#include <aerial_autonomy/{0}.h>"
+        ).format(event_manager_tuple[0],)
+        accumulate_event_manager_classes.append(
+            '::'.join(event_manager_tuple) + '<LogicStateMachine>')
+        accumulate_event_manager_names.append(
+            event_manager_tuple[0] + '_manager')
+
 
 if __name__ == "__main__":
     if len(sys.argv) != 3:
@@ -77,23 +142,36 @@ if __name__ == "__main__":
     out_file = open(os.path.join(sys.argv[2], evt_file_wext), 'w')
     # Print header
     print >> out_file, (
+        "#pragma once\n"
         "/** Auto generated header file from event file\n"
         "  Do not edit this file manually **/\n"
         "#include <functional>\n"
         "#include <iostream>\n"
         "#include <stdexcept>\n"
         "#include <set>\n"
-        "#include <unordered_map>\n"
+        "#include <unordered_map>"
     )
     # Enclose the events and event manager into namespace
-    print >> out_file, "namespace %s {" % (evt_file_base,)
     accumulate_event_map = []
+    accumulate_event_manager_classes = []
+    accumulate_event_manager_names = []
     event_names_list = f.read().splitlines()
+    # Add sub event managers if exist
+    print >>out_file, ""
+    for event_name in event_names_list[1:]:
+        event_name = event_name.strip()
+        create_sub_event_manager(event_name, accumulate_event_manager_classes,
+                                 accumulate_event_manager_names, out_file)
+    print >>out_file, ""
+    print >> out_file, "namespace %s {" % (evt_file_base,)
     event_manager_name = event_names_list[0][:-1]
     for event_name in event_names_list[1:]:
         event_name = event_name.strip()
-        create_event(event_name, accumulate_event_map, out_file)
+        if not check_event_manager(event_name):
+            create_event(event_name, accumulate_event_map, out_file)
     print >>out_file, "\n//Event manager class"
-    create_event_manager(event_manager_name, accumulate_event_map, out_file)
+    create_event_manager(event_manager_name, accumulate_event_map,
+                         accumulate_event_manager_classes,
+                         accumulate_event_manager_names, out_file)
     print >>out_file, "}"
     out_file.close()

--- a/tests/event_manager_tests/event_manager_tests.cpp
+++ b/tests/event_manager_tests/event_manager_tests.cpp
@@ -21,7 +21,7 @@ namespace basic_events{
 TEST(BasicEventManagerTest, InstantiateManager) {
   ASSERT_NO_THROW(new BasicEventManager<LogicStateMachine>());
 }
-TEST(BasicEventManagerTest, PrintEventMap) {
+TEST(BasicEventManagerTest, CheckEventSet) {
   BasicEventManager<LogicStateMachine> event_manager;
   std::set<std::string> event_set = event_manager.getEventSet();
   std::set<std::string> expected_set { "Land", "Takeoff", "Abort"};
@@ -30,8 +30,7 @@ TEST(BasicEventManagerTest, PrintEventMap) {
 TEST(BasicEventManagerTest, TriggerWrongEvent) {
   BasicEventManager<LogicStateMachine> event_manager;
   LogicStateMachine logic_state_machine;
-  ASSERT_THROW((event_manager.triggerEvent("FollowTrajectory",logic_state_machine)),
-               std::runtime_error);
+  ASSERT_FALSE(event_manager.triggerEvent("FollowTrajectory",logic_state_machine));
 }
 TEST(BasicEventManagerTest, TriggerEvents) {
   BasicEventManager<LogicStateMachine> event_manager;
@@ -49,6 +48,18 @@ TEST(VisualServoingEventManagerTest, TriggerEvents) {
   LogicStateMachine logic_state_machine;
   event_manager.triggerEvent("FollowTrajectory", logic_state_machine);
   ASSERT_EQ(logic_state_machine.type_index_event_, std::type_index(typeid(FollowTrajectory)));
+}
+TEST(VisualServoingEventManagerTest, TriggerBasicEvent) {
+  VisualServoingEventManager<LogicStateMachine> event_manager;
+  LogicStateMachine logic_state_machine;
+  event_manager.triggerEvent("Land", logic_state_machine);
+  ASSERT_EQ(logic_state_machine.type_index_event_, std::type_index(typeid(basic_events::Land)));
+}
+TEST(VisualServoingEventManagerTest, CheckEventSet) {
+  VisualServoingEventManager<LogicStateMachine> event_manager;
+  std::set<std::string> event_set = event_manager.getEventSet();
+  std::set<std::string> expected_set { "Land", "Takeoff", "Abort", "FollowTrajectory"};
+  ASSERT_TRUE(event_set == expected_set);
 }
 }
 ///


### PR DESCRIPTION
Add option to include other event managers as sub modules
in current event manager. For example, basic_events is added
as a sub event manager in visual_servoing_events.

This option is added to ensure the events are same across different
event files for a given event. The takeoff should be same between
visual_servoing_events and basic_events. This lets one trigger
appropriate events from actions without changing which file the
event belongs to.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jhu-asco/aerial_autonomy/8)
<!-- Reviewable:end -->
