### PR TITLE
Add hardware type to controller_hardware_connector

### DIFF
--- a/include/aerial_autonomy/controller_hardware_connectors/base_controller_hardware_connector.h
+++ b/include/aerial_autonomy/controller_hardware_connectors/base_controller_hardware_connector.h
@@ -2,6 +2,14 @@
 #include <aerial_autonomy/controllers/base_controller.h>
 
 /**
+* @brief Type of hardware used by controllerhardwareconnector
+*/
+enum class HardwareType{
+  Quadrotor, // Only quadrotor
+  Arm, // Only arm
+};
+
+/**
 * @brief Base for ControllerHardwareConnector class
 */
 struct AbstractControllerHardwareConnector {
@@ -9,6 +17,7 @@ public:
   virtual void run() = 0;
   virtual ~AbstractControllerHardwareConnector() {}
 };
+
 
 /**
 * @brief Performs a single step of extracting data, running controller
@@ -21,9 +30,10 @@ public:
 template <class SensorDataType, class GoalType, class ControlType>
 class ControllerHardwareConnector : public AbstractControllerHardwareConnector {
 public:
+
   ControllerHardwareConnector(
-      Controller<SensorDataType, GoalType, ControlType> &controller)
-      : AbstractControllerHardwareConnector(), controller_(controller) {}
+      Controller<SensorDataType, GoalType, ControlType> &controller, HardwareType hardware_type)
+      : AbstractControllerHardwareConnector(), hardware_type_(hardware_type), controller_(controller) {}
 
   /**
    * @brief Extracts sensor data, run controller and send data back to hardware
@@ -49,6 +59,10 @@ public:
    */
   GoalType getGoal() { return controller_.getGoal(); }
 
+  HardwareType getHardwareType() {
+    return hardware_type_;
+  }
+
 protected:
   /**
    * @brief  extract relevant data from hardware/estimators
@@ -63,6 +77,16 @@ protected:
    * @param controls Data structure the quadrotor is expecting
    */
   virtual void sendHardwareCommands(ControlType controls) = 0;
+
+protected:
+  /**
+  * @brief Type of hardware controlled by the controller
+  *
+  * Used to group controllers. Only one controller will be running
+  * per hardware.
+  *
+  */
+  HardwareType hardware_type_;
 
 private:
   /**

--- a/include/aerial_autonomy/controller_hardware_connectors/builtin_velocity_controller_drone_connector.h
+++ b/include/aerial_autonomy/controller_hardware_connectors/builtin_velocity_controller_drone_connector.h
@@ -18,7 +18,7 @@ public:
   BuiltInVelocityControllerDroneConnector(
       parsernode::Parser &drone_hardware,
       Controller<EmptySensor, VelocityYaw, VelocityYaw> &controller)
-      : ControllerHardwareConnector(controller),
+      : ControllerHardwareConnector(controller, HardwareType::Quadrotor),
         drone_hardware_(drone_hardware) {}
 
 protected:

--- a/include/aerial_autonomy/controller_hardware_connectors/manual_rpyt_controller_drone_connector.h
+++ b/include/aerial_autonomy/controller_hardware_connectors/manual_rpyt_controller_drone_connector.h
@@ -13,7 +13,7 @@ public:
   ManualRPYTControllerDroneConnector(
       parsernode::Parser &drone_hardware,
       Controller<JoysticksYaw, EmptyGoal, RollPitchYawThrust> &controller)
-      : ControllerHardwareConnector(controller),
+      : ControllerHardwareConnector(controller, HardwareType::Quadrotor),
         drone_hardware_(drone_hardware) {}
 
 protected:

--- a/include/aerial_autonomy/controller_hardware_connectors/position_controller_drone_connector.h
+++ b/include/aerial_autonomy/controller_hardware_connectors/position_controller_drone_connector.h
@@ -19,7 +19,7 @@ public:
   PositionControllerDroneConnector(
       parsernode::Parser &drone_hardware,
       Controller<EmptySensor, PositionYaw, PositionYaw> &controller)
-      : ControllerHardwareConnector(controller),
+      : ControllerHardwareConnector(controller, HardwareType::Quadrotor),
         drone_hardware_(drone_hardware) {}
 
 protected:

--- a/include/aerial_autonomy/robot_systems/quadrotor_system.h
+++ b/include/aerial_autonomy/robot_systems/quadrotor_system.h
@@ -1,0 +1,110 @@
+#pragma once
+
+#include <aerial_autonomy/controller_hardware_connectors/base_controller_hardware_connector.h>
+// Position Control Stuff
+#include <aerial_autonomy/controller_hardware_connectors/position_controller_drone_connector.h>
+#include <aerial_autonomy/controllers/builtin_controller.h>
+// store controller hardware connectors
+#include <unordered_map>
+// get type info for each controller hardware connector class
+#include <typeindex>
+// Boost thread stuff
+#include <boost/thread/mutex.hpp>
+// Unique ptr
+#include <memory>
+
+/**
+ * Owns, initializes, and facilitates communication between different
+ * hardware/software components.
+ * Provides builtin position, velocity, and rpy controllers for controlling quadrotor
+*/
+class QuadRotorSystem {
+  // May be use shared pointers
+  class ControllerHardwareConnectorContainer {
+    // Map to store the controller to hardware connectors
+    std::unordered_map<std::type_index, AbstractControllerHardwareConnector* > controller_hardware_connector_map_;
+  public:
+    // Set
+    template<class ControllerHardwareConnectorT>
+    void addControllerHardwareConnector(ControllerHardwareConnectorT &controller_hardware_connector) {
+      controller_hardware_connector_map_[typeid(controller_hardware_connector)] = &controller_hardware_connector;
+    }
+    // Get
+    template<class ControllerHardwareConnectorT>
+    ControllerHardwareConnectorT* getControllerHardwareConnector() {
+      return static_cast<ControllerHardwareConnectorT>(controller_hardware_connector_map_[typeid(ControllerHardwareConnectorT)]);
+    }
+  };
+
+private:
+  // Hardware:
+  parsernode::Parser &drone_hardware_;
+  // Controllers
+  BuiltInController<PositionYaw> builtin_position_controller_;
+  // Controller connectors
+  PositionControllerDroneConnector position_controller_drone_connector_;
+  // Container to store and retrieve controller-hardware-connectors
+  ControllerHardwareConnectorContainer controller_hardware_connector_container_;
+  // Maps to store and swap active controller
+  std::map<HardwareType, AbstractControllerHardwareConnector*> active_controllers_;
+  std::map<HardwareType, std::unique_ptr<boost::mutex> > thread_mutexes_;
+public:
+  QuadRotorSystem(parsernode::Parser &drone_hardware):
+    drone_hardware_(drone_hardware),
+    position_controller_drone_connector_(drone_hardware, builtin_position_controller_)
+  {
+    // Add control hardware connector containers
+    controller_hardware_connector_container_.addControllerHardwareConnector(position_controller_drone_connector_);
+    // Initialize active controller map
+    active_controllers_[HardwareType::Arm] = nullptr;
+    thread_mutexes_[HardwareType::Arm] = std::unique_ptr<boost::mutex>(new boost::mutex);
+
+    active_controllers_[HardwareType::Quadrotor] = nullptr;
+    thread_mutexes_[HardwareType::Quadrotor] = std::unique_ptr<boost::mutex>(new boost::mutex);
+  }
+  // Get sensor data from quadrotor:
+  parsernode::common::quaddata getQuadData() {
+      parsernode::common::quaddata data;
+      drone_hardware_.getquaddata(data);
+      return data;
+  }
+
+  // Calls to set goals to controllers and send commands to hardwareAbstractControllerHardwareConnector
+  void takeOff() {
+    drone_hardware_.takeoff();
+  }
+
+  void land() {
+    drone_hardware_.land();
+  }
+
+  template <class ControllerHardwareContainerT, class GoalT>
+  void setGoal(GoalT goal) {
+    ControllerHardwareContainerT *controller_hardware_connector = controller_hardware_connector_container_.getControllerHardwareConnector<ControllerHardwareContainerT>();
+    controller_hardware_connector->setGoal(goal);
+    HardwareType hardware_type = controller_hardware_connector->getHardwareType();
+    if(active_controllers_[hardware_type] != controller_hardware_connector) {
+      boost::mutex::scoped_lock lock(*thread_mutexes_[hardware_type]);
+      active_controllers_[hardware_type] = controller_hardware_connector;
+    }
+  }
+  template <class ControllerHardwareContainerT, class GoalT>
+  GoalT getGoal() {
+    ControllerHardwareContainerT *controller_hardware_connector = controller_hardware_connector_container_.getControllerHardwareConnector<ControllerHardwareContainerT>();
+    return controller_hardware_connector->getGoal();
+  }
+
+  void abortController(HardwareType hardware_type) {
+    boost::mutex::scoped_lock lock(*thread_mutexes_[hardware_type]);
+    active_controllers_[hardware_type] = nullptr;
+  }
+
+  void activeControllerRun(HardwareType hardware_type) {
+    // lock to ensure active_control fcn is not changed
+    AbstractControllerHardwareConnector *active_controller = active_controllers_[hardware_type];
+    if(active_controller != nullptr) {
+      boost::mutex::scoped_lock lock(*thread_mutexes_[hardware_type]);
+      active_controller->run();
+    }
+  }
+};

--- a/tests/controller_hardware_connectors/controller_hardware_tests.cpp
+++ b/tests/controller_hardware_connectors/controller_hardware_tests.cpp
@@ -11,7 +11,7 @@ class SampleController : public Controller<int, int, int> {
 class SampleHardwareController : ControllerHardwareConnector<int, int, int> {
 public:
   SampleHardwareController(Controller<int, int, int> &controller)
-      : ControllerHardwareConnector<int, int, int>(controller) {}
+      : ControllerHardwareConnector<int, int, int>(controller, HardwareType::Arm) {}
   virtual void sendHardwareCommands(int) { return; }
 
   virtual int extractSensorData() { return 0; }


### PR DESCRIPTION
Including hardware type is necessary to group the connectors
based on hardware. Only one type of connector is active per
hardware. This is only a software grouping and does not actually
check if the correct hardware is being used or not. This allows
for using optimal control connectors which use both quadrotor
and arm to be grouped under one of the existing hardware type
categories.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jhu-asco/aerial_autonomy/12)
<!-- Reviewable:end -->
