### PR TITLE
Clang fix all code

### DIFF
--- a/include/aerial_autonomy/actions_guards/basic_states.h
+++ b/include/aerial_autonomy/actions_guards/basic_states.h
@@ -1,5 +1,5 @@
 // States and actions corresponding to basic events
-#include <aerial_autonomy/actions_guards/land_functors.h>
-#include <aerial_autonomy/actions_guards/takeoff_functors.h>
 #include <aerial_autonomy/actions_guards/hovering_functors.h>
+#include <aerial_autonomy/actions_guards/land_functors.h>
 #include <aerial_autonomy/actions_guards/position_control_functors.h>
+#include <aerial_autonomy/actions_guards/takeoff_functors.h>

--- a/include/aerial_autonomy/actions_guards/hovering_functors.h
+++ b/include/aerial_autonomy/actions_guards/hovering_functors.h
@@ -1,10 +1,9 @@
 #pragma once
 #include <aerial_autonomy/actions_guards/base_functors.h>
+#include <aerial_autonomy/basic_events.h>
 #include <aerial_autonomy/logic_states/base_state.h>
 #include <aerial_autonomy/robot_systems/uav_system.h>
-#include <aerial_autonomy/basic_events.h>
 #include <parsernode/common.h>
-
 
 /**
 * @brief Internal action when hovering.

--- a/include/aerial_autonomy/actions_guards/land_functors.h
+++ b/include/aerial_autonomy/actions_guards/land_functors.h
@@ -1,8 +1,8 @@
 #pragma once
 #include <aerial_autonomy/actions_guards/base_functors.h>
+#include <aerial_autonomy/basic_events.h>
 #include <aerial_autonomy/logic_states/base_state.h>
 #include <aerial_autonomy/robot_systems/uav_system.h>
-#include <aerial_autonomy/basic_events.h>
 #include <aerial_autonomy/types/completed_event.h>
 #include <parsernode/common.h>
 
@@ -23,7 +23,6 @@ struct LandTransitionActionFunctor_
     robot_system.land();
   }
 };
-
 
 /**
 * @brief Internal action to figure out when landing is complete

--- a/include/aerial_autonomy/actions_guards/position_control_functors.h
+++ b/include/aerial_autonomy/actions_guards/position_control_functors.h
@@ -1,10 +1,10 @@
 #pragma once
 #include <aerial_autonomy/actions_guards/base_functors.h>
+#include <aerial_autonomy/basic_events.h>
+#include <aerial_autonomy/controller_hardware_connectors/position_controller_drone_connector.h>
 #include <aerial_autonomy/logic_states/base_state.h>
 #include <aerial_autonomy/robot_systems/uav_system.h>
-#include <aerial_autonomy/basic_events.h>
 #include <aerial_autonomy/types/completed_event.h>
-#include <aerial_autonomy/controller_hardware_connectors/position_controller_drone_connector.h>
 #include <parsernode/common.h>
 
 using namespace basic_events;
@@ -37,7 +37,8 @@ struct PositionControlAbortActionFunctor_
 };
 
 /**
-* @brief Guard function to check the goal is within tolerance before starting towards goal
+* @brief Guard function to check the goal is within tolerance before starting
+* towards goal
 *
 * \todo Use a parameter for setting position tolerance
 *

--- a/include/aerial_autonomy/actions_guards/takeoff_functors.h
+++ b/include/aerial_autonomy/actions_guards/takeoff_functors.h
@@ -1,8 +1,8 @@
 #pragma once
 #include <aerial_autonomy/actions_guards/base_functors.h>
+#include <aerial_autonomy/basic_events.h>
 #include <aerial_autonomy/logic_states/base_state.h>
 #include <aerial_autonomy/robot_systems/uav_system.h>
-#include <aerial_autonomy/basic_events.h>
 #include <aerial_autonomy/types/completed_event.h>
 #include <parsernode/common.h>
 
@@ -69,7 +69,8 @@ struct TakeoffInternalActionFunctor_
   * @brief Function to check when takeoff is complete.
   * If battery is low while takeoff, trigger Land event
   *
-  *  \todo add a parameter for height when to transition from takeoff to hovering
+  *  \todo add a parameter for height when to transition from takeoff to
+  * hovering
   *
   * @param robot_system robot system to get sensor data
   * @param logic_state_machine logic state machine to trigger events

--- a/include/aerial_autonomy/controller_hardware_connectors/base_controller_hardware_connector.h
+++ b/include/aerial_autonomy/controller_hardware_connectors/base_controller_hardware_connector.h
@@ -27,7 +27,6 @@ public:
   virtual ~AbstractControllerHardwareConnector() {}
 };
 
-
 /**
 * @brief Performs a single step of extracting data, running controller
 * and sending data back to hardware
@@ -54,8 +53,10 @@ public:
   * running per hardware type.
   */
   ControllerHardwareConnector(
-      Controller<SensorDataType, GoalType, ControlType> &controller, HardwareType hardware_type)
-      : AbstractControllerHardwareConnector(), hardware_type_(hardware_type), controller_(controller) {}
+      Controller<SensorDataType, GoalType, ControlType> &controller,
+      HardwareType hardware_type)
+      : AbstractControllerHardwareConnector(), hardware_type_(hardware_type),
+        controller_(controller) {}
 
   /**
    * @brief Extracts sensor data, run controller and send data back to hardware
@@ -86,9 +87,7 @@ public:
   *
   * @return return the type of hardware used by the controller
   */
-  HardwareType getHardwareType() {
-    return hardware_type_;
-  }
+  HardwareType getHardwareType() { return hardware_type_; }
 
 protected:
   /**

--- a/include/aerial_autonomy/robot_systems/uav_system.h
+++ b/include/aerial_autonomy/robot_systems/uav_system.h
@@ -25,16 +25,33 @@ private:
   */
   parsernode::Parser &drone_hardware_;
   // Controllers
-  BuiltInController<PositionYaw> builtin_position_controller_;///< position controller
-  BuiltInController<VelocityYaw> builtin_velocity_controller_;///< velocity controller
-  ManualRPYTController manual_rpyt_controller_;///< rpyt controller using joystick
-  // Controller connectors
-  PositionControllerDroneConnector position_controller_drone_connector_;///< connector for position controller
-  BuiltInVelocityControllerDroneConnector velocity_controller_drone_connector_;///< connector for velocity controller
-  ManualRPYTControllerDroneConnector rpyt_controller_drone_connector_;///< connector for rpyt controller
   /**
-  * @brief Container to store and retrieve controller-hardware-connectors
+  * @brief Position Controller
   */
+  BuiltInController<PositionYaw> builtin_position_controller_;
+  /**
+  * @brief  velocity controller
+  */
+  BuiltInController<VelocityYaw> builtin_velocity_controller_;
+  /**
+  * @brief rpyt controller using joystick controller connectors
+  */
+  ManualRPYTController manual_rpyt_controller_;
+  /**
+   * @brief connector for position controller
+   */
+  PositionControllerDroneConnector position_controller_drone_connector_;
+  /**
+  * @brief connector for velocity controller
+  */
+  BuiltInVelocityControllerDroneConnector velocity_controller_drone_connector_;
+  /**
+  * @brief connector for rpyt controller
+  */
+  ManualRPYTControllerDroneConnector rpyt_controller_drone_connector_;
+  /**
+   * @brief Container to store and retrieve controller-hardware-connectors
+   */
   TypeMap<AbstractControllerHardwareConnector>
       controller_hardware_connector_container_;
   /**
@@ -52,7 +69,8 @@ public:
   /**
   * @brief Constructor
   *
-  * UAVSystem requires a drone hardware. It instantiates the connectors, controllers 
+  * UAVSystem requires a drone hardware. It instantiates the connectors,
+  * controllers
   *
   * @param drone_hardware input hardware to send commands back
   */
@@ -141,7 +159,8 @@ public:
   /**
   * @brief Remove active controller for given hardware type
   *
-  * @param hardware_type Type of hardware for which active controller is switched off
+  * @param hardware_type Type of hardware for which active controller is
+  * switched off
   */
   void abortController(HardwareType hardware_type) {
     boost::mutex::scoped_lock lock(*thread_mutexes_[hardware_type]);

--- a/include/aerial_autonomy/tests/sample_logic_state_machine.h
+++ b/include/aerial_autonomy/tests/sample_logic_state_machine.h
@@ -11,7 +11,8 @@ struct EmptyRobotSystem {};
 /**
 * @brief Example Logic state machine that stores triggered event
 *
-* @tparam RobotSystemT The robot system that is used by states to perform actions
+* @tparam RobotSystemT The robot system that is used by states to perform
+* actions
 */
 template <class RobotSystemT> class SampleLogicStateMachine_ {
   /**

--- a/include/aerial_autonomy/tests/sample_parser.h
+++ b/include/aerial_autonomy/tests/sample_parser.h
@@ -71,7 +71,8 @@ public:
   * @brief Command the euler angles of the quad and the thrust.
   *
   * @param rpytmsg Msg format is (x,y,z,w) -> (roll, pitch, yaw, thrust).
-  * The thrust value will be adjusted based on whethere there is thrust bias or not.
+  * The thrust value will be adjusted based on whethere there is thrust bias or
+  * not.
   * @param sendyaw True to control the yaw/ False to ignore yaw command
   *
   * @return True if sending command is successful
@@ -133,7 +134,8 @@ public:
 
   // PluginLib initialization function
   /**
-  * @brief Initialize the Hardware with a ros node handle to setup communications
+  * @brief Initialize the Hardware with a ros node handle to setup
+  * communications
   *
   * @param nh_ Nodehandle to setup communications
   */

--- a/include/aerial_autonomy/types/empty_sensor.h
+++ b/include/aerial_autonomy/types/empty_sensor.h
@@ -1,6 +1,6 @@
 #pragma once
 /**
-* @brief Events that do not need sensor data such as builtin position/velocity controllers
+* @brief Events that do not need sensor data such as builtin position/velocity
+* controllers
 */
-struct EmptySensor {
-};
+struct EmptySensor {};

--- a/include/aerial_autonomy/types/joysticks.h
+++ b/include/aerial_autonomy/types/joysticks.h
@@ -18,8 +18,8 @@ struct Joysticks {
   Joysticks(double channel1, double channel2, double channel3, double channel4)
       : channel1(channel1), channel2(channel2), channel3(channel3),
         channel4(channel4) {}
-  double channel1;///< First channel
-  double channel2;///< Second channel
-  double channel3;///< Third channel
-  double channel4;///< Fourth channel
+  double channel1; ///< First channel
+  double channel2; ///< Second channel
+  double channel3; ///< Third channel
+  double channel4; ///< Fourth channel
 };

--- a/include/aerial_autonomy/types/joysticks_yaw.h
+++ b/include/aerial_autonomy/types/joysticks_yaw.h
@@ -21,5 +21,5 @@ struct JoysticksYaw : public Joysticks {
   JoysticksYaw(double channel1, double channel2, double channel3,
                double channel4, double yaw)
       : Joysticks(channel1, channel2, channel3, channel4), yaw(yaw) {}
-  double yaw;///< Yaw data stored internally
+  double yaw; ///< Yaw data stored internally
 };

--- a/include/aerial_autonomy/types/position.h
+++ b/include/aerial_autonomy/types/position.h
@@ -16,16 +16,17 @@ struct Position {
   * @param z z component in m
   */
   Position(double x, double y, double z) : x(x), y(y), z(z) {}
-  double x;///< x component in m
-  double y;///< y component in m
-  double z;///< z component in m
+  double x; ///< x component in m
+  double y; ///< y component in m
+  double z; ///< z component in m
+
   /**
-  * @brief Compare two positions
-  *
-  * @param p Position to compare against
-  *
-  * @return True if two positions are same
-  */
+   * @brief Compare two positions
+   *
+   * @param p Position to compare against
+   *
+   * @return True if two positions are same
+   */
   bool operator==(const Position &p) const {
     return (x == p.x && y == p.y && z == p.z);
   }

--- a/include/aerial_autonomy/types/position_yaw.h
+++ b/include/aerial_autonomy/types/position_yaw.h
@@ -30,14 +30,15 @@ struct PositionYaw : public Position {
   */
   PositionYaw(double x, double y, double z, double yaw)
       : Position(x, y, z), yaw(yaw) {}
-  double yaw;///< Orientation about body axis rad
+  double yaw; ///< Orientation about body axis rad
+
   /**
-  * @brief Compare two position and yaw entities
-  *
-  * @param p PositionYaw to compare against
-  *
-  * @return True if position and yaw are the same
-  */
+   * @brief Compare two position and yaw entities
+   *
+   * @param p PositionYaw to compare against
+   *
+   * @return True if position and yaw are the same
+   */
   bool operator==(const PositionYaw &p) const {
     return (Position::operator==(p) && yaw == p.yaw);
   }

--- a/include/aerial_autonomy/types/roll_pitch_yaw_thrust.h
+++ b/include/aerial_autonomy/types/roll_pitch_yaw_thrust.h
@@ -17,8 +17,8 @@ struct RollPitchYawThrust {
   */
   RollPitchYawThrust(double r, double p, double y, double t)
       : r(r), p(p), y(y), t(t) {}
-  double r;///< roll
-  double p;///< pitch
-  double y;///< yaw
-  double t;///< thrust
+  double r; ///< roll
+  double p; ///< pitch
+  double y; ///< yaw
+  double t; ///< thrust
 };

--- a/include/aerial_autonomy/types/velocity.h
+++ b/include/aerial_autonomy/types/velocity.h
@@ -16,16 +16,17 @@ struct Velocity {
   * @param z z component (m/s)
   */
   Velocity(double x, double y, double z) : x(x), y(y), z(z) {}
-  double x;///< x component in m/s
-  double y;///< y component in m/s
-  double z;///< z component in m/s
+  double x; ///< x component in m/s
+  double y; ///< y component in m/s
+  double z; ///< z component in m/s
+
   /**
-  * @brief Check if two velocity vectors are the same
-  *
-  * @param v The vector agains which the current vector is compared.
-  *
-  * @return True if vectors are equal
-  */
+   * @brief Check if two velocity vectors are the same
+   *
+   * @param v The vector agains which the current vector is compared.
+   *
+   * @return True if vectors are equal
+   */
   bool operator==(const Velocity &v) const {
     return (x == v.x && y == v.y && z == v.z);
   }

--- a/include/aerial_autonomy/types/velocity_yaw.h
+++ b/include/aerial_autonomy/types/velocity_yaw.h
@@ -29,14 +29,15 @@ struct VelocityYaw : public Velocity {
   */
   VelocityYaw(double x, double y, double z, double yaw)
       : Velocity(x, y, z), yaw(yaw) {}
-  double yaw;///< Orientation around global z axis
+  double yaw; ///< Orientation around global z axis
+
   /**
-  * @brief Compare two velocityyaws
-  *
-  * @param v VelocityYaw to compare against
-  *
-  * @return True if same
-  */
+   * @brief Compare two velocityyaws
+   *
+   * @param v VelocityYaw to compare against
+   *
+   * @return True if same
+   */
   bool operator==(const VelocityYaw &v) const {
     return (Velocity::operator==(v) && yaw == v.yaw);
   }

--- a/setup/clang_format_file.bash
+++ b/setup/clang_format_file.bash
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Script to convert a given file to clang format
+#
+
+# Get base name without path
+function clang_format_file {
+  arg=$1
+  file_name=${arg##*/}
+  echo "Copying $file_name to temp file"
+  cp $1 /tmp/$file_name
+  clang-format /tmp/$file_name > $1
+}
+
+if [[ -f $1 ]];
+then
+  echo "Formatting file $1"
+  clang_format_file $1 
+elif [[ -d $1 ]];
+then
+  echo "Formatting files in directory $1"
+  file_list=$(find $1 \( -name '*.cpp' -o -name '*.h' -o -name '*.C' -o -name '*.H', -o -name '*.hpp'  \))
+  for file_name in $file_list; do
+    echo "Formatting file $file_name"
+    clang_format_file $file_name
+  done
+else
+  echo "Usage: clang_format_file.bash [NAME]
+        NAME: File or folder name
+          If NAME is a file, the file is clang formatted
+          else if NAME is a directory, all the c++ files
+          matching *.h, *.hpp, *.H *.C, *.cpp will be
+          formatted into clang format 
+       "
+fi

--- a/src/controller_hardware_connectors/position_controller_drone_connector.cpp
+++ b/src/controller_hardware_connectors/position_controller_drone_connector.cpp
@@ -4,7 +4,8 @@ EmptySensor PositionControllerDroneConnector::extractSensorData() {
   return EmptySensor();
 }
 
-void PositionControllerDroneConnector::sendHardwareCommands(PositionYaw controls) {
+void PositionControllerDroneConnector::sendHardwareCommands(
+    PositionYaw controls) {
   geometry_msgs::Vector3 position_command;
   position_command.x = controls.x;
   position_command.y = controls.y;

--- a/tests/actions_guards/basic_functor_tests.cpp
+++ b/tests/actions_guards/basic_functor_tests.cpp
@@ -1,7 +1,7 @@
-#include <gtest/gtest.h>
-#include <aerial_autonomy/tests/sample_parser.h>
-#include <aerial_autonomy/tests/sample_logic_state_machine.h>
 #include <aerial_autonomy/actions_guards/basic_states.h>
+#include <aerial_autonomy/tests/sample_logic_state_machine.h>
+#include <aerial_autonomy/tests/sample_parser.h>
+#include <gtest/gtest.h>
 #include <typeindex>
 // Land
 using LandTransitionActionFunctor =

--- a/tests/common/type_map_tests.cpp
+++ b/tests/common/type_map_tests.cpp
@@ -1,5 +1,5 @@
-#include <gtest/gtest.h>
 #include <aerial_autonomy/common/type_map.h>
+#include <gtest/gtest.h>
 
 //// \brief Definitions
 ///  Define any necessary subclasses for tests here

--- a/tests/controller_hardware_connectors/controller_hardware_tests.cpp
+++ b/tests/controller_hardware_connectors/controller_hardware_tests.cpp
@@ -11,7 +11,8 @@ class SampleController : public Controller<int, int, int> {
 class SampleHardwareController : ControllerHardwareConnector<int, int, int> {
 public:
   SampleHardwareController(Controller<int, int, int> &controller)
-      : ControllerHardwareConnector<int, int, int>(controller, HardwareType::Arm) {}
+      : ControllerHardwareConnector<int, int, int>(controller,
+                                                   HardwareType::Arm) {}
   virtual void sendHardwareCommands(int) { return; }
 
   virtual int extractSensorData() { return 0; }

--- a/tests/event_manager_tests/event_manager_tests.cpp
+++ b/tests/event_manager_tests/event_manager_tests.cpp
@@ -1,6 +1,6 @@
 #include <aerial_autonomy/basic_events.h>
-#include <aerial_autonomy/visual_servoing_events.h>
 #include <aerial_autonomy/tests/sample_logic_state_machine.h>
+#include <aerial_autonomy/visual_servoing_events.h>
 #include <gtest/gtest.h>
 #include <iostream>
 #include <typeindex>
@@ -9,21 +9,22 @@ using namespace std;
 
 /// \brief TEST
 /// All the tests are defined here
-namespace basic_events{
+namespace basic_events {
 TEST(BasicEventManagerTest, InstantiateManager) {
   ASSERT_NO_THROW(new BasicEventManager<SampleLogicStateMachine>());
 }
 TEST(BasicEventManagerTest, CheckEventSet) {
   BasicEventManager<SampleLogicStateMachine> event_manager;
   std::set<std::string> event_set = event_manager.getEventSet();
-  std::set<std::string> expected_set { "Land", "Takeoff", "Abort"};
+  std::set<std::string> expected_set{"Land", "Takeoff", "Abort"};
   ASSERT_EQ(event_set, expected_set);
 }
 TEST(BasicEventManagerTest, TriggerWrongEvent) {
   BasicEventManager<SampleLogicStateMachine> event_manager;
   EmptyRobotSystem robot_system;
   SampleLogicStateMachine logic_state_machine(robot_system);
-  ASSERT_FALSE(event_manager.triggerEvent("FollowTrajectory",logic_state_machine));
+  ASSERT_FALSE(
+      event_manager.triggerEvent("FollowTrajectory", logic_state_machine));
 }
 TEST(BasicEventManagerTest, TriggerEvents) {
   BasicEventManager<SampleLogicStateMachine> event_manager;
@@ -34,7 +35,7 @@ TEST(BasicEventManagerTest, TriggerEvents) {
             std::type_index(typeid(Land)));
 }
 }
-namespace visual_servoing_events{
+namespace visual_servoing_events {
 TEST(VisualServoingEventManagerTest, InstantiateManager) {
   ASSERT_NO_THROW(new VisualServoingEventManager<SampleLogicStateMachine>());
 }
@@ -57,7 +58,8 @@ TEST(VisualServoingEventManagerTest, TriggerBasicEvent) {
 TEST(VisualServoingEventManagerTest, CheckEventSet) {
   VisualServoingEventManager<SampleLogicStateMachine> event_manager;
   std::set<std::string> event_set = event_manager.getEventSet();
-  std::set<std::string> expected_set { "Land", "Takeoff", "Abort", "FollowTrajectory"};
+  std::set<std::string> expected_set{"Land", "Takeoff", "Abort",
+                                     "FollowTrajectory"};
   ASSERT_TRUE(event_set == expected_set);
 }
 }

--- a/tests/robot_systems/uav_system_tests.cpp
+++ b/tests/robot_systems/uav_system_tests.cpp
@@ -1,6 +1,6 @@
-#include <gtest/gtest.h>
 #include <aerial_autonomy/robot_systems/uav_system.h>
 #include <aerial_autonomy/tests/sample_parser.h>
+#include <gtest/gtest.h>
 
 /// \brief Test UAV System
 TEST(UAVSystemTests, Constructor) {


### PR DESCRIPTION
Fix all the c++ code to follow clang format manually. Since the git clang format script checks only the commited changes, the old code in the files is causing problems when commiting. This commit ensures all the code is clang formatted so that from now on we do not have issues with clang formatting difference between commited and uncommited code

Note: Before merging this branch, merge doxygen_documentation PR.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jhu-asco/aerial_autonomy/19)
<!-- Reviewable:end -->
