### PR TITLE
Remove build before test coverage generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,8 @@ CMakeLists.txt.user
 *.pyc
 *.swp
 doxy_errors.txt
-documentation_coverage_info/*
-test_coverage_info/*
+.documentation_coverage_info/*
+.test_coverage_info/*
 docs/
 scripts/generate_test_coverage.bash
 .vscode

--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ To skip pre-commit hooks and force a commit, use `git commit -n`.
 ## Documentation Coverage
 We use coverxygen to generate documentation coverage for the doc: https://github.com/psycofdj/coverxygen
 
-Use the script `scripts/generate_documentation_coverage.bash` to generate documentation into `documentation_coverage_info` folder.
-Check the html page in `documentation_coverage_info/index.html` to verify the documentation coverage of the code.
+Use the script `scripts/generate_documentation_coverage.bash` to generate documentation into `.documentation_coverage_info` folder.
+Check the html page in `.documentation_coverage_info/index.html` to verify the documentation coverage of the code.
 
 Documentation coverage is also added as a `pre-push` hook. This verifies that 95% of the code is covered with documentation before pushing to remote. It can be skipped for branches with their name starting with `develop*` and also by using `git push --no-verify` command.
 
 ## Test Coverage
-We use `lcov` to generate the test coverage report into the `test_coverage_info` folder. The script `scripts/generate_test_coverage.bash` is used to run tests in the project and generate test coverage report into `test_coverage_info` folder. The script is generated using CMake. Run `catkin build aerial_autonomy` to create the script. Check the html page `test_coverage_info/index.html` to check the line and function coverage. The bash script is generated
+We use `lcov` to generate the test coverage report into the `.test_coverage_info` folder. The script `scripts/generate_test_coverage.bash` is used to run tests in the project and generate test coverage report into `.test_coverage_info` folder. The script is generated using CMake. Run `catkin build aerial_autonomy` to create the script. Check the html page `.test_coverage_info/index.html` to check the line and function coverage. The bash script is generated
 by running CMake using `catkin build aerial_autonomy`.
 
 The test generation is integrated into the `pre-push` commit hook. This runs the above test coverage generation script and verifies that the coverage level is above 95% threshold. This can be skipped by either naming the branch as `develop[your_branch_name]` or using `git push --no-verify`.

--- a/scripts/generate_documentation_coverage.bash
+++ b/scripts/generate_documentation_coverage.bash
@@ -5,10 +5,10 @@ echo $PWD
 echo "Generating Docs"
 doxygen > /dev/null # Generates docs
 # Create coverage folder if it does not exist
-[ -d documentation_coverage_info ] || mkdir documentation_coverage_info
+[ -d .documentation_coverage_info ] || mkdir .documentation_coverage_info
 echo "Coverage report"
-python -m coverxygen --xml-dir ./docs/xml --src-dir . --output ./documentation_coverage_info/doc_coverage.info > /dev/null
+python -m coverxygen --xml-dir ./docs/xml --src-dir . --output ./.documentation_coverage_info/doc_coverage.info > /dev/null
 echo "Generate HTML Report"
-genhtml --no-function-coverage --no-branch-coverage documentation_coverage_info/doc_coverage.info -o ./documentation_coverage_info > /dev/null
+genhtml --no-function-coverage --no-branch-coverage .documentation_coverage_info/doc_coverage.info -o ./.documentation_coverage_info > /dev/null
 echo "Print Summary"
-lcov --summary ./documentation_coverage_info/doc_coverage.info
+lcov --summary ./.documentation_coverage_info/doc_coverage.info

--- a/scripts/generate_test_coverage.bash.in
+++ b/scripts/generate_test_coverage.bash.in
@@ -1,4 +1,5 @@
 #!/bin/bash
+rm -rf ${CMAKE_CURRENT_BINARY_DIR}
 catkin run_tests aerial_autonomy > /dev/null
 error=$?
 if [ $error -ne 0 ]
@@ -6,7 +7,7 @@ then
   echo "Catkin BUILD Failed"
   exit 1
 fi
-TEST_COVERAGE_DIR=${CMAKE_CURRENT_SOURCE_DIR}/test_coverage_info
+TEST_COVERAGE_DIR=${CMAKE_CURRENT_SOURCE_DIR}/.test_coverage_info
 if [ ! -d "$TEST_COVERAGE_DIR" ]; then
   mkdir $TEST_COVERAGE_DIR
 fi

--- a/scripts/setup/hooks/pre-push
+++ b/scripts/setup/hooks/pre-push
@@ -12,10 +12,10 @@ cd $GIT_REPO_PATH
 echo "Generating documentation coverage report..."
 doxygen $GIT_REPO_PATH/Doxyfile > /dev/null
 # Create coverage folder if it does not exist
-[ -d documentation_coverage_info ] || mkdir documentation_coverage_info
-python -m coverxygen --xml-dir ./docs/xml --src-dir . --output ./documentation_coverage_info/doc_coverage.info > /dev/null
+[ -d .documentation_coverage_info ] || mkdir .documentation_coverage_info
+python -m coverxygen --xml-dir ./docs/xml --src-dir . --output ./.documentation_coverage_info/doc_coverage.info > /dev/null
 echo "Checking documentation Coverage..."
-./scripts/test_coverage.py --threshold $threshold ./documentation_coverage_info/doc_coverage.info
+./scripts/test_coverage.py --threshold $threshold ./.documentation_coverage_info/doc_coverage.info
 error=$?
 if [ $error -ne 0 ]
 then
@@ -25,7 +25,7 @@ then
     echo "The documentation coverage is $codecoverage percentage"
     echo "The code is short by $error percentage"
     echo "Running documentation coverage html generation script"
-    genhtml --no-function-coverage --no-branch-coverage documentation_coverage_info/doc_coverage.info -o ./documentation_coverage_info > /dev/null
+    genhtml --no-function-coverage --no-branch-coverage .documentation_coverage_info/doc_coverage.info -o ./.documentation_coverage_info > /dev/null
     lcov --summary ./documentation_coverage_info/doc_coverage.info
     echo "Check code-coverage-info/index.html for detailed code generation stats"
     exit 1;
@@ -49,7 +49,7 @@ fi
 # Check test coverage
 threshold=95
 echo "Checking test coverage..."
-./scripts/test_coverage.py --threshold $threshold ./test_coverage_info/test_coverage.info
+./scripts/test_coverage.py --threshold $threshold ./.test_coverage_info/test_coverage.info
 error=$?
 if [ $error -ne 0 ]
 then


### PR DESCRIPTION
Remove build folder before test coverage generation. Make test/documentation coverage info folders hidden to reduce clutter

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jhu-asco/aerial_autonomy/58)
<!-- Reviewable:end -->
