### PR TITLE
Add script to generate dot files for state machine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,6 @@ doxy_errors.txt
 .test_coverage_info/*
 docs/
 scripts/generate_test_coverage.bash
+scripts/generate_dot_files.py
 .vscode
+.dot_output/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -385,3 +385,5 @@ install(FILES plugin.xml
 
 ## Configure script to generate test coverage
 configure_file(scripts/generate_test_coverage.bash.in ${CMAKE_CURRENT_SOURCE_DIR}/scripts/generate_test_coverage.bash)
+## Configure script to generate dot files for state machines
+configure_file(scripts/generate_dot_files.py.in ${CMAKE_CURRENT_SOURCE_DIR}/scripts/generate_dot_files.py)

--- a/README.md
+++ b/README.md
@@ -65,3 +65,8 @@ The test generation is integrated into the `pre-push` commit hook. This runs the
 
 ## Uploading documentation
 The documentation is uploaded through `gh-pages` branch. The docs are created in master and passed to the `gh-pages` branch using `scripts/applydocs.bash` script. The script checks that there are not uncommited changes before uploading documentation to avoid issues with git. The script also requires that you explicitly link gh-pages branch to the remote using `git branch --set-upstream-to=[GH_PAGES_REMOTE]`
+
+## Generating Visual graphs from state machines
+The script `scripts/generate_dot_files.py` converts the transition tables in state machines to dot format and also png format. The script automatically runs through all the state machines stored in the `include/aerial_autonomy/state_machines` folder.
+
+    Usage: ./generate_dot_files.py

--- a/scripts/generate_dot_files.py.in
+++ b/scripts/generate_dot_files.py.in
@@ -66,7 +66,6 @@ def generate_dot_files(file_path, out_folder):
         dot_out += '\t"{0}"->"{2}"[label="{1}"];\n'.format(*states_actions[:3])
 
     dot_out += '}'
-    # dot_file = tkFileDialog.asksaveasfile(mode='w', defaultextension=".gv")
     dot_file = file(os.path.join(out_folder, file_name_short + '.gv'), 'w')
     if dot_file is None:
         print "Cannot Save File. Instead Printing the dot format!"

--- a/scripts/generate_dot_files.py.in
+++ b/scripts/generate_dot_files.py.in
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+"""
+Created on Fri Jun 23 08:46:37 2017
+
+Goal: Convert boost state machine into a dot graph.
+
+@author: gowtham
+"""
+
+import os
+import re
+
+transition_table_pattern = re.compile(
+    ".*struct +transition_table *: *boost::mpl::vector<(.*)> *{")
+transition_header_pattern = re.compile("msmf::Row<(.*)")
+block_comment_pattern = re.compile("/\*.*?\*/", re.DOTALL)
+single_comment_pattern = re.compile("//.*?\n")
+
+
+def removeComments(string):
+    """
+    Remove block and single comments from the string and return a copy
+    """
+    global block_comment_pattern, single_comment_pattern
+    # remove all occurance streamed comments (/*COMMENT */) from string
+    string = re.sub(block_comment_pattern, "", string)
+    # remove all occurance singleline comments (//COMMENT\n ) from string
+    string = re.sub(single_comment_pattern, "", string)
+    return string
+
+
+def removeNewLines(string):
+    """
+    Remove new lines from the string and return a copy
+    """
+    return string.replace('\n', '')
+
+
+def generate_dot_files(file_path, out_folder):
+    """
+    Generate a dot file and a png file
+    Parameters
+    file_path  - Input state machine header file
+    out_folder - Folder to save dot graph and png file
+    """
+    global transition_table_pattern, transition_header_pattern
+    with open(file_path) as f:
+        input_text = f.read()
+    input_text_cleaned = removeNewLines(removeComments(input_text))
+    # %%
+    transition_table_out = transition_table_pattern.match(input_text_cleaned)
+    if transition_table_out is None:
+        raise RuntimeError("Cannot find transition table!")
+
+    transition_table_str = transition_table_out.group(1)
+    transitions = transition_table_str.split(">,")
+    for i, transition in enumerate(transitions):
+        transitions[i] = transition.replace(' ', '')  # Replace spaces
+
+    # %% Write dot output
+    file_name_short = os.path.basename(file_path).split('.')[0]
+    dot_out = "digraph {0} {{\n".format(file_name_short)
+    for transition in transitions:
+        match_obj = transition_header_pattern.match(transition)
+        states_actions = match_obj.group(1).split(',')
+        dot_out += '\t"{0}"->"{2}"[label="{1}"];\n'.format(*states_actions[:3])
+
+    dot_out += '}'
+    # dot_file = tkFileDialog.asksaveasfile(mode='w', defaultextension=".gv")
+    dot_file = file(os.path.join(out_folder, file_name_short + '.gv'), 'w')
+    if dot_file is None:
+        print "Cannot Save File. Instead Printing the dot format!"
+        print dot_out
+    else:
+        dot_file.write(dot_out)
+        dot_file.close()
+
+    # Generate png file
+    os.popen("dot {0}.gv "
+             "-Tpng > {0}.png".format(os.path.join(out_folder,
+                                                   file_name_short)))
+
+if __name__ == '__main__':
+    state_machine_folder = ("${PROJECT_SOURCE_DIR}/include/"
+                            "aerial_autonomy/state_machines")
+    state_machine_files = os.listdir(state_machine_folder)
+    dot_out_folder = "${PROJECT_SOURCE_DIR}/.dot_output"
+    if not os.path.exists(dot_out_folder):
+        os.mkdir(dot_out_folder)
+    for state_machine_file in state_machine_files:
+        if (state_machine_file != 'base_state_machine.h' and
+                state_machine_file != 'state_machine_gui_connector.h'):
+            state_machine_file_full_path = os.path.join(state_machine_folder,
+                                                        state_machine_file)
+            generate_dot_files(state_machine_file_full_path, dot_out_folder)


### PR DESCRIPTION
The dot files are stored .dot_out folder. The script is run
using generate_dot_files.py file which is run when cmake is used
It automatically tries to graph all the files in state machine
folder except base state machine and state machine connector.
Additional files can be added to the script

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jhu-asco/aerial_autonomy/66)
<!-- Reviewable:end -->
