### PR TITLE
Add reset picking if visual servoing is lost or placing is complete

### DIFF
--- a/include/aerial_autonomy/actions_guards/hovering_functors.h
+++ b/include/aerial_autonomy/actions_guards/hovering_functors.h
@@ -52,7 +52,7 @@ struct HoveringInternalActionFunctor_
 * @tparam check_completed If false, ignores check on controller completion
 */
 template <class LogicStateMachineT, class ControllerConnector,
-          bool check_completed = true>
+          bool check_completed = true, class AbortEventT = be::Abort>
 struct ControllerStatusInternalActionFunctor_
     : InternalActionFunctor<UAVSystem, LogicStateMachineT> {
   /**
@@ -72,7 +72,7 @@ struct ControllerStatusInternalActionFunctor_
     } else if (status == ControllerStatus::Critical) {
       LOG(WARNING) << "Controller critical for "
                    << typeid(ControllerConnector).name();
-      logic_state_machine.process_event(be::Abort());
+      logic_state_machine.process_event(AbortEventT());
       return false;
     }
     return true;

--- a/include/aerial_autonomy/actions_guards/pick_place_functors.h
+++ b/include/aerial_autonomy/actions_guards/pick_place_functors.h
@@ -80,7 +80,7 @@ using PrePickInternalActionFunctor_ =
             LogicStateMachineT, VisualServoingControllerArmConnector>,
         ControllerStatusInternalActionFunctor_<
             LogicStateMachineT,
-            RelativePoseVisualServoingControllerDroneConnector, false>>>;
+            RelativePoseVisualServoingControllerDroneConnector, false, Reset>>>;
 
 /**
 * @brief Logic to check while placing object
@@ -94,7 +94,7 @@ using PlaceInternalActionFunctor_ =
         ArmStatusInternalActionFunctor_<LogicStateMachineT>,
         ControllerStatusInternalActionFunctor_<
             LogicStateMachineT,
-            RelativePoseVisualServoingControllerDroneConnector>>>;
+            RelativePoseVisualServoingControllerDroneConnector, true, Reset>>>;
 
 /**
 * @brief Logic to check arm power and manual mode

--- a/include/aerial_autonomy/actions_guards/pick_place_states_actions.h
+++ b/include/aerial_autonomy/actions_guards/pick_place_states_actions.h
@@ -183,6 +183,10 @@ struct PickPlaceStatesActions
   */
   using ReachingPostPlaceWaypoint =
       FollowingWaypointSequence_<LogicStateMachineT, 2, 3>;
+  /**
+  * @brief State for resetting visual servoing
+  */
+  struct ResetVisualServoing : ReachingGoal_<LogicStateMachineT> {};
 
   // Explicitly defined manual Control state
   /**

--- a/include/aerial_autonomy/actions_guards/visual_servoing_functors.h
+++ b/include/aerial_autonomy/actions_guards/visual_servoing_functors.h
@@ -6,6 +6,7 @@
 #include <aerial_autonomy/logic_states/base_state.h>
 #include <aerial_autonomy/robot_systems/uav_vision_system.h>
 #include <aerial_autonomy/types/completed_event.h>
+#include <aerial_autonomy/types/reset_event.h>
 #include <glog/logging.h>
 #include <parsernode/common.h>
 /**
@@ -139,7 +140,7 @@ using RelativePoseVisualServoingInternalActionFunctor_ =
         UAVStatusInternalActionFunctor_<LogicStateMachineT>,
         ControllerStatusInternalActionFunctor_<
             LogicStateMachineT,
-            RelativePoseVisualServoingControllerDroneConnector>>>;
+            RelativePoseVisualServoingControllerDroneConnector, true, Reset>>>;
 
 /**
 * @brief Check tracking is valid

--- a/include/aerial_autonomy/state_machines/pick_place_state_machine.h
+++ b/include/aerial_autonomy/state_machines/pick_place_state_machine.h
@@ -223,6 +223,14 @@ public:
                       psa::ReachingPostPlaceWaypoint, psa::ArmGripAction<false>,
                       psa::PostPlaceWaypointGuard>,
             //        +--------------+-------------+--------------+---------------------+---------------------------+
+            //        Both the start and end states below check the status of
+            //        the same controller internally
+            //        So after transition, the ResetVisualServoing will try to
+            //        emit Completed event to transition
+            //        into Picking again. \todo Add a state for waiting for
+            //        object and both reachingPostPlaceWaypoint
+            //        and ResetVisualServoing should transition into waiting
+            //        state
             msmf::Row<psa::ReachingPostPlaceWaypoint, Completed,
                       psa::ResetVisualServoing, msmf::none, msmf::none>,
             //        +--------------+-------------+--------------+---------------------+---------------------------+

--- a/include/aerial_autonomy/state_machines/pick_place_state_machine.h
+++ b/include/aerial_autonomy/state_machines/pick_place_state_machine.h
@@ -137,6 +137,14 @@ public:
                       psa::RelativePoseVisualServoingWithReset,
                       psa::RelativePoseVisualServoingTransitionGuard>,
             //        +--------------+-------------+--------------+---------------------+---------------------------+
+            msmf::Row<psa::ResetVisualServoing, Completed,
+                      psa::RelativePoseVisualServoing,
+                      psa::RelativePoseVisualServoingWithReset,
+                      psa::RelativePoseVisualServoingTransitionGuard>,
+            //        +--------------+-------------+--------------+---------------------+---------------------------+
+            msmf::Row<psa::ResetVisualServoing, be::Abort, psa::Hovering,
+                      psa::AbortUAVArmController, msmf::none>,
+            //        +--------------+-------------+--------------+---------------------+---------------------------+
             msmf::Row<psa::Hovering, VelocityYaw, psa::ExecutingVelocityGoal,
                       psa::SetVelocityGoal, psa::GuardVelocityGoal>,
             //        +--------------+-------------+--------------+---------------------+---------------------------+
@@ -144,11 +152,18 @@ public:
                       psa::PrePickState, psa::PrePickTransitionAction,
                       psa::PrePickTransitionGuard>,
             //        +--------------+-------------+--------------+---------------------+---------------------------+
+            msmf::Row<psa::RelativePoseVisualServoing, Reset,
+                      psa::ResetVisualServoing, psa::GoHomeTransitionAction,
+                      psa::GoHomeTransitionGuard>,
+            //        +--------------+-------------+--------------+---------------------+---------------------------+
             msmf::Row<psa::RelativePoseVisualServoing, be::Abort, psa::Hovering,
                       psa::UAVControllerAbort, msmf::none>,
             //        +--------------+-------------+--------------+---------------------+---------------------------+
             msmf::Row<psa::PrePickState, Completed, psa::PickState,
                       psa::PickTransitionAction, psa::PickGuard>,
+            //        +--------------+-------------+--------------+---------------------+---------------------------+
+            msmf::Row<psa::PrePickState, Reset, psa::ResetVisualServoing,
+                      psa::GoHomeTransitionAction, psa::GoHomeTransitionGuard>,
             //        +--------------+-------------+--------------+---------------------+---------------------------+
             msmf::Row<psa::Hovering, vse::GoHome, psa::ReachingGoal,
                       psa::GoHomeTransitionAction, psa::GoHomeTransitionGuard>,
@@ -187,7 +202,7 @@ public:
             msmf::Row<psa::ReachingGoal, Completed, psa::Hovering,
                       psa::AbortUAVControllerArmRightFold, msmf::none>,
             //        +--------------+-------------+--------------+---------------------+---------------------------+
-            msmf::Row<psa::PickState, Reset, psa::ReachingGoal,
+            msmf::Row<psa::PickState, Reset, psa::ResetVisualServoing,
                       psa::GoHomeTransitionAction, psa::GoHomeTransitionGuard>,
             //        +--------------+-------------+--------------+---------------------+---------------------------+
             msmf::Row<psa::PickState, Completed, psa::ReachingPostPickWaypoint,
@@ -208,8 +223,8 @@ public:
                       psa::ReachingPostPlaceWaypoint, psa::ArmGripAction<false>,
                       psa::PostPlaceWaypointGuard>,
             //        +--------------+-------------+--------------+---------------------+---------------------------+
-            msmf::Row<psa::ReachingPostPlaceWaypoint, Completed, psa::Hovering,
-                      psa::AbortUAVArmController, msmf::none>,
+            msmf::Row<psa::ReachingPostPlaceWaypoint, Completed,
+                      psa::ResetVisualServoing, msmf::none, msmf::none>,
             //        +--------------+-------------+--------------+---------------------+---------------------------+
             msmf::Row<psa::ReachingPostPlaceWaypoint, be::Abort, psa::Hovering,
                       psa::AbortUAVArmController, msmf::none>,
@@ -233,11 +248,12 @@ public:
 /**
 * @brief state names to get name based on state id
 */
-static constexpr std::array<const char *, 15> state_names = {
+static constexpr std::array<const char *, 16> state_names = {
     "Landed",
     "ArmPreTakeoffFolding",
     "Takingoff",
     "Hovering",
+    "ResetVisualServoing",
     "RelativePoseVisualServoing",
     "PrePickState",
     "ArmPreLandingFolding",


### PR DESCRIPTION
The reset state checks for reached goal and tries to enter pick
again if reaching goal is complete

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jhu-asco/aerial_autonomy/120)
<!-- Reviewable:end -->
