### PR TITLE
Integrate acceleration bias estimator

### DIFF
--- a/include/aerial_autonomy/controller_connectors/rpyt_relative_pose_visual_servoing_connector.h
+++ b/include/aerial_autonomy/controller_connectors/rpyt_relative_pose_visual_servoing_connector.h
@@ -3,6 +3,7 @@
 #include "aerial_autonomy/controller_connectors/base_relative_pose_visual_servoing_connector.h"
 #include "aerial_autonomy/controllers/rpyt_based_relative_pose_controller.h"
 #include "aerial_autonomy/estimators/thrust_gain_estimator.h"
+#include "aerial_autonomy/estimators/acceleration_bias_estimator.h"
 #include "aerial_autonomy/trackers/base_tracker.h"
 #include "aerial_autonomy/types/position_yaw.h"
 #include "aerial_autonomy/types/roll_pitch_yawrate_thrust.h"
@@ -36,6 +37,7 @@ public:
       BaseTracker &tracker, parsernode::Parser &drone_hardware,
       RPYTBasedRelativePoseController &controller,
       ThrustGainEstimator &thrust_gain_estimator,
+      AccelerationBiasEstimator &acceleration_bias_estimator,
       tf::Transform camera_transform,
       tf::Transform tracking_offset_transform = tf::Transform::getIdentity())
       : ControllerConnector(controller, ControllerGroup::UAV),
@@ -43,6 +45,7 @@ public:
                                                 camera_transform,
                                                 tracking_offset_transform),
         thrust_gain_estimator_(thrust_gain_estimator),
+        acceleration_bias_estimator_(acceleration_bias_estimator),
         private_reference_controller_(controller) {
     logTrackerHeader("rpyt_relative_pose_visual_servoing_connector");
   }
@@ -90,6 +93,10 @@ private:
    * the acceleration in body z direction
    */
   ThrustGainEstimator &thrust_gain_estimator_;
+  /**
+   * @brief Estimator for computing acceleration bias
+   */
+  AccelerationBiasEstimator &acceleration_bias_estimator_;
   /**
    * @brief Internal reference to controller that is connected by this class
    */

--- a/proto/uav_vision_system_config.proto
+++ b/proto/uav_vision_system_config.proto
@@ -8,6 +8,7 @@ import "tracking_vector_estimator_config.proto";
 import "particle_reference_config.proto";
 import "polynomial_reference_config.proto";
 import "velocity_based_relative_pose_controller_config.proto";
+import "acceleration_bias_estimator_config.proto";
 
 message UAVVisionSystemConfig {
   required ConstantHeadingDepthControllerConfig
@@ -69,4 +70,9 @@ message UAVVisionSystemConfig {
   */
   optional VelocityBasedRelativePoseControllerConfig
       velocity_based_relative_pose_controller_config = 14;
+  /**
+  * @brief Config for acceleration bias estimator
+  */
+  optional AccelerationBiasEstimatorConfig
+      acceleration_bias_estimator_config = 15;
 }

--- a/src/estimators/thrust_gain_estimator.cpp
+++ b/src/estimators/thrust_gain_estimator.cpp
@@ -18,8 +18,8 @@ ThrustGainEstimator::ThrustGainEstimator(
       max_roll_pitch_bias_(max_roll_pitch_bias),
       init_roll_bias_(init_roll_bias), init_pitch_bias_(init_pitch_bias) {
   CHECK_GE(delay_buffer_size_, 1) << "Buffer size should be atleast 1";
-  CHECK_GT(mixing_gain_, 0) << "Mixing gain should be between 0 and 1";
-  CHECK_LT(mixing_gain_, 1) << "Mixing gain should be between 0 and 1";
+  CHECK_GE(mixing_gain_, 0) << "Mixing gain should be between 0 and 1";
+  CHECK_LE(mixing_gain_, 1) << "Mixing gain should be between 0 and 1";
   CHECK_GT(rp_mixing_gain_, 0) << "Mixing gain should be between 0 and 1";
   CHECK_LT(rp_mixing_gain_, 1) << "Mixing gain should be between 0 and 1";
   CHECK_GE(thrust_gain_initial, min_thrust_gain_)
@@ -122,7 +122,7 @@ void ThrustGainEstimator::resetThrustMixingGain() {
 }
 
 void ThrustGainEstimator::setThrustMixingGain(double mixing_gain) {
-  CHECK_GT(mixing_gain, 0) << "Mixing gain should be between 0 and 1";
-  CHECK_LT(mixing_gain, 1) << "Mixing gain should be between 0 and 1";
+  CHECK_GE(mixing_gain, 0) << "Mixing gain should be between 0 and 1";
+  CHECK_LE(mixing_gain, 1) << "Mixing gain should be between 0 and 1";
   mixing_gain_ = mixing_gain;
 }


### PR DESCRIPTION
Integrates the acceleration bias estimator into the RPYT relative pose visual servoing controller.  **Review and merge the add-acc-bias-estimator branch first before reviewing this!**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jhu-asco/aerial_autonomy/210)
<!-- Reviewable:end -->
